### PR TITLE
Change from EPYC CPU type to "host"

### DIFF
--- a/debian-11-bullseye.pkr.hcl
+++ b/debian-11-bullseye.pkr.hcl
@@ -94,7 +94,7 @@ source "proxmox-iso" "debian-11" {
   cloud_init_storage_pool = var.cloudinit_storage_pool
 
   vm_name  = "debian-11.4.0-amd64"
-  cpu_type = "EPYC"
+  cpu_type = "host"
   os       = "l26"
   memory   = var.memory
   cores    = var.cores


### PR DESCRIPTION
This was causing me trouble attempting to pack an image on an Intel CPU. Changing it to "host" will default to what ever the system is.

We could probably make the case for "kvm64"? But improved performance seems closer to the EPYC setting you had already.

https://developer.hashicorp.com/packer/plugins/builders/proxmox/iso#cpu_type